### PR TITLE
make region-bindings-mode-{en,dis}able interactive

### DIFF
--- a/region-bindings-mode.el
+++ b/region-bindings-mode.el
@@ -100,11 +100,13 @@ Don't use this, use `region-bindings-mode-disable'."
 
 (defun region-bindings-mode-enable ()
   "Add initialization hooks."
+  (interactive)
   (add-hook 'activate-mark-hook 'region-bindings-mode-on)
   (add-hook 'deactivate-mark-hook 'region-bindings-mode-off))
 
 (defun region-bindings-mode-disable ()
   "Remove initialization hooks and turn off."
+  (interactive)
   (remove-hook 'activate-mark-hook 'region-bindings-mode-on)
   (remove-hook 'deactivate-mark-hook 'region-bindings-mode-off)
   (region-bindings-mode -1))


### PR DESCRIPTION
They should be interactive functions so that the user can easily enable
or disable the mode for individual buffers, and optionally bind
enabling/disabling to key sequences.
